### PR TITLE
Wellswizard header column color changed

### DIFF
--- a/com.ltts.wellspoc/src/com/ltts/wellspoc/ui/wellselection/WellSelectionUISupport.java
+++ b/com.ltts.wellspoc/src/com/ltts/wellspoc/ui/wellselection/WellSelectionUISupport.java
@@ -107,7 +107,7 @@ public class WellSelectionUISupport {
 		wellTable.setLinesVisible(true);
 		
 		//change color of column header
-		wellTable.setHeaderForeground(Display.getDefault().getSystemColor(SWT.COLOR_LINK_FOREGROUND));
+		wellTable.setHeaderForeground(Display.getDefault().getSystemColor(SWT.COLOR_WHITE));
 		wellTable.setHeaderBackground(Display.getDefault().getSystemColor(SWT.COLOR_GRAY));
 
 		// Get the content for the viewer.

--- a/com.ltts.wellspoc/src/com/ltts/wellspoc/ui/wellselection/WellSelectionUISupport.java
+++ b/com.ltts.wellspoc/src/com/ltts/wellspoc/ui/wellselection/WellSelectionUISupport.java
@@ -106,7 +106,8 @@ public class WellSelectionUISupport {
 
 		wellTable.setLinesVisible(true);
 		
-		//change color of column header
+		//change color of column header with white foreground color
+		
 		wellTable.setHeaderForeground(Display.getDefault().getSystemColor(SWT.COLOR_WHITE));
 		wellTable.setHeaderBackground(Display.getDefault().getSystemColor(SWT.COLOR_GRAY));
 


### PR DESCRIPTION
Problem:
 Table selection header WellName and WellSelection was too dark in wells wizard

Approach:
Changed the font color to white colour

Test:
Tested all possible scenarios in my development environment.